### PR TITLE
Allow one column

### DIFF
--- a/egs/elpis/asr1/run.sh
+++ b/egs/elpis/asr1/run.sh
@@ -117,13 +117,15 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
     wc -l ${dict}
 
     # make json labels
-    data2json.sh --feat ${feat_tr_dir}/feats.scp \
+    data2json.sh --feat ${feat_tr_dir}/feats.scp --allow-one-column true \
          data/${train_set} ${dict} > ${feat_tr_dir}/data.json
-    data2json.sh --feat ${feat_dt_dir}/feats.scp \
+
+    data2json.sh --feat ${feat_dt_dir}/feats.scp --allow-one-column true \
          data/${train_dev} ${dict} > ${feat_dt_dir}/data.json
+
     for rtask in ${recog_set}; do
         feat_recog_dir=${dumpdir}/${rtask}/delta${do_delta}
-        data2json.sh --feat ${feat_recog_dir}/feats.scp \
+        data2json.sh --feat ${feat_recog_dir}/feats.scp --allow-one-column true \
             data/${rtask} ${dict} > ${feat_recog_dir}/data.json
     done
 fi


### PR DESCRIPTION
Using the Agricultural Activities data, training with epsnet in Elpis gave this error:

```
stage 2: Dictionary and Json Data Preparation
52 data/lang_1char/train_nodev_units.txt
/espnet/utils/data2json.sh --feat dump/train_nodev/deltafalse/feats.scp data/train_nodev data/lang_1char/train_nodev_units.txt
/espnet/utils/feat_to_shape.sh --cmd run.pl --nj 1 --filetype  --preprocess-conf  --verbose 0 dump/train_nodev/deltafalse/feats.scp data/train_nodev/tmp-nMkh7/input_1/shape.scp
Traceback (most recent call last):
  File "/espnet/utils/merge_scp2json.py", line 223, in <module>
    .format(nutt, info[1], line))
RuntimeError: Format error 100th line in data/train_nodev/tmp-nMkh7/output/text.scp:  Expecting "<key> <value>":

```

Setting `--allow-one-column` according to espnet/espnet/issues/1150#issuecomment-525988534  avoids the `<key> <value>` error. What are the implications for other data formats that have been used in testing?

